### PR TITLE
fix(package.json): add tree-sitter.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "bindings/node/*",
     "queries/*",
     "src/**",
+    "tree-sitter.json",
     "*.wasm"
   ]
 }


### PR DESCRIPTION
This will include tree-sitter.json in the npm package, should this repo be published.